### PR TITLE
Make the user_id column big integer

### DIFF
--- a/src/database/migrations/2020_01_13_150351_create_password_history_table.php
+++ b/src/database/migrations/2020_01_13_150351_create_password_history_table.php
@@ -17,11 +17,9 @@ class CreatePasswordHistoryTable extends Migration
             static function (Blueprint $table) {
                 $table->bigIncrements('id');
 
-                $table->unsignedInteger('user_id');
-                $table->foreign('user_id')
-                      ->references('id')
-                      ->on(config('password-history.tables.users.name', 'users'))
-                      ->onDelete('cascade');
+                $table->foreignId('user_id')
+                      ->constrained(config('password-history.tables.users.name', 'users'))
+                      ->cascadeOnDelete();
 
                 $table->string('password');
 


### PR DESCRIPTION
By changing this, the package migration will be compatible with the default laravel migration for the users table.